### PR TITLE
Bug 1405410 — Rendering graph (including legend) from a test.

### DIFF
--- a/MappaMundi.xcodeproj/project.pbxproj
+++ b/MappaMundi.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		392FB353200E1D5D0014867E /* MMTestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392FB352200E1D5D0014867E /* MMTestUtils.swift */; };
 		3962F2291FF6A6C100999008 /* Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3962F2281FF6A6C100999008 /* Wait.swift */; };
 		3962F22B1FF6A75800999008 /* ScreenGraphEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3962F22A1FF6A75800999008 /* ScreenGraphEdge.swift */; };
 		39658ADC1FF699AA000544A2 /* MMScreenStateNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39658ADB1FF699AA000544A2 /* MMScreenStateNode.swift */; };
@@ -14,6 +15,7 @@
 		39658AE01FF69F62000544A2 /* MMScreenActionNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39658ADF1FF69F62000544A2 /* MMScreenActionNode.swift */; };
 		39658AE21FF6A065000544A2 /* MMUserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39658AE11FF6A065000544A2 /* MMUserState.swift */; };
 		397334491FF6AAA600C45ECE /* MMGraphNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397334481FF6AAA600C45ECE /* MMGraphNode.swift */; };
+		39870718200D16710067B070 /* GraphRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39870717200D16710067B070 /* GraphRepresentation.swift */; };
 		39AB5FDE1FE4560D00008FB3 /* DemoMappaMundi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AB5FDD1FE4560D00008FB3 /* DemoMappaMundi.swift */; };
 		39AB5FEC1FE4597800008FB3 /* MMScreenGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AB5FDB1FE455C700008FB3 /* MMScreenGraph.swift */; };
 		39AB5FF21FE45FF500008FB3 /* MappaMundi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39AB5FE41FE4595000008FB3 /* MappaMundi.framework */; };
@@ -50,6 +52,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		392FB352200E1D5D0014867E /* MMTestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MMTestUtils.swift; sourceTree = "<group>"; };
 		3962F2281FF6A6C100999008 /* Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Wait.swift; path = ../Sources/Wait.swift; sourceTree = "<group>"; };
 		3962F22A1FF6A75800999008 /* ScreenGraphEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScreenGraphEdge.swift; path = ../Sources/ScreenGraphEdge.swift; sourceTree = "<group>"; };
 		39658ADB1FF699AA000544A2 /* MMScreenStateNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MMScreenStateNode.swift; path = ../Sources/MMScreenStateNode.swift; sourceTree = "<group>"; };
@@ -57,6 +60,7 @@
 		39658ADF1FF69F62000544A2 /* MMScreenActionNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MMScreenActionNode.swift; path = ../Sources/MMScreenActionNode.swift; sourceTree = "<group>"; };
 		39658AE11FF6A065000544A2 /* MMUserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MMUserState.swift; path = ../Sources/MMUserState.swift; sourceTree = "<group>"; };
 		397334481FF6AAA600C45ECE /* MMGraphNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MMGraphNode.swift; path = Sources/MMGraphNode.swift; sourceTree = SOURCE_ROOT; };
+		39870717200D16710067B070 /* GraphRepresentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GraphRepresentation.swift; path = Sources/GraphRepresentation.swift; sourceTree = SOURCE_ROOT; };
 		39AB5FDB1FE455C700008FB3 /* MMScreenGraph.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MMScreenGraph.swift; path = ../Sources/MMScreenGraph.swift; sourceTree = "<group>"; };
 		39AB5FDD1FE4560D00008FB3 /* DemoMappaMundi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoMappaMundi.swift; sourceTree = "<group>"; };
 		39AB5FE41FE4595000008FB3 /* MappaMundi.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MappaMundi.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -106,12 +110,14 @@
 			isa = PBXGroup;
 			children = (
 				39AB5FDB1FE455C700008FB3 /* MMScreenGraph.swift */,
-				3962F22A1FF6A75800999008 /* ScreenGraphEdge.swift */,
 				397334481FF6AAA600C45ECE /* MMGraphNode.swift */,
+				392FB352200E1D5D0014867E /* MMTestUtils.swift */,
 				39658ADF1FF69F62000544A2 /* MMScreenActionNode.swift */,
 				39658ADB1FF699AA000544A2 /* MMScreenStateNode.swift */,
 				39658ADD1FF69BCE000544A2 /* MMNavigator.swift */,
 				39658AE11FF6A065000544A2 /* MMUserState.swift */,
+				39870717200D16710067B070 /* GraphRepresentation.swift */,
+				3962F22A1FF6A75800999008 /* ScreenGraphEdge.swift */,
 				3962F2281FF6A6C100999008 /* Wait.swift */,
 				39AB5FE61FE4595000008FB3 /* MappaMundi.h */,
 				39AB5FE71FE4595000008FB3 /* Info.plist */,
@@ -335,11 +341,13 @@
 			files = (
 				397334491FF6AAA600C45ECE /* MMGraphNode.swift in Sources */,
 				39658ADC1FF699AA000544A2 /* MMScreenStateNode.swift in Sources */,
+				39870718200D16710067B070 /* GraphRepresentation.swift in Sources */,
 				39658AE21FF6A065000544A2 /* MMUserState.swift in Sources */,
 				3962F22B1FF6A75800999008 /* ScreenGraphEdge.swift in Sources */,
 				39658AE01FF69F62000544A2 /* MMScreenActionNode.swift in Sources */,
 				39658ADE1FF69BCE000544A2 /* MMNavigator.swift in Sources */,
 				3962F2291FF6A6C100999008 /* Wait.swift in Sources */,
+				392FB353200E1D5D0014867E /* MMTestUtils.swift in Sources */,
 				39AB5FEC1FE4597800008FB3 /* MMScreenGraph.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MappaMundi/MMTestUtils.swift
+++ b/MappaMundi/MMTestUtils.swift
@@ -59,9 +59,9 @@ enum UIDeviceError: Error, CustomDebugStringConvertible {
     var debugDescription: String {
         switch self {
         case .cannotDetectUser:
-            return "Couldn't find Snapshot configuration files - can't detect current user "
+            return "Couldn't find MappaMundi configuration files - can't detect current user "
         case .cannotFindHomeDirectory:
-            return "Couldn't find Snapshot configuration files - can't detect `Users` dir"
+            return "Couldn't find MappaMundi configuration files - can't detect `Users` dir"
         case .cannotFindSimulatorHomeDirectory:
             return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
         case .cannotAccessSimulatorHomeDirectory(let simulatorHostHome):

--- a/MappaMundi/MMTestUtils.swift
+++ b/MappaMundi/MMTestUtils.swift
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import UIKit
+
+open class MMTestUtils {
+    public static func render<T>(graph: MMScreenGraph<T>, with renderer: GraphRepresentation = DotRepresentation()) {
+        if let file = writeableURL(filename: "graph.\(renderer.fileExtension)") {
+            print("Writing to \(file.absoluteString)")
+            try? graph.stringRepresentation(renderer).write(to: file, atomically: true, encoding: .utf8)
+        }
+    }
+
+    static func writeableURL(directory: String = "Library/Caches/tools.mappamundi", filename: String) -> URL? {
+        let homeDir = try? UIDevice.current.homeDirectory()
+        let dir = homeDir?.appendingPathComponent(directory)
+        return URL(string: filename, relativeTo: dir)
+    }
+}
+
+/// This is largely taken from SnapshotHelper, but duplicated here to be independent from Snapshot.
+
+extension UIDevice {
+    func homeDirectory() throws -> URL {
+        let homeDir: URL
+        // on OSX config is stored in /Users/<username>/Library
+        // and on iOS/tvOS/WatchOS it's in simulator's home dir
+        #if os(OSX)
+            guard let user = ProcessInfo().environment["USER"] else {
+                throw DeviceError.cannotDetectUser
+            }
+
+            guard let usersDir =  FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
+                throw DeviceError.cannotFindHomeDirectory
+            }
+
+            homeDir = usersDir.appendingPathComponent(user)
+        #else
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw UIDeviceError.cannotFindSimulatorHomeDirectory
+            }
+            guard let homeDirUrl = URL(string: simulatorHostHome) else {
+                throw UIDeviceError.cannotAccessSimulatorHomeDirectory(simulatorHostHome)
+            }
+            homeDir = URL(fileURLWithPath: homeDirUrl.path)
+        #endif
+        return homeDir
+    }
+}
+
+enum UIDeviceError: Error, CustomDebugStringConvertible {
+    case cannotDetectUser
+    case cannotFindHomeDirectory
+    case cannotFindSimulatorHomeDirectory
+    case cannotAccessSimulatorHomeDirectory(String)
+
+    var debugDescription: String {
+        switch self {
+        case .cannotDetectUser:
+            return "Couldn't find Snapshot configuration files - can't detect current user "
+        case .cannotFindHomeDirectory:
+            return "Couldn't find Snapshot configuration files - can't detect `Users` dir"
+        case .cannotFindSimulatorHomeDirectory:
+            return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+        case .cannotAccessSimulatorHomeDirectory(let simulatorHostHome):
+            return "Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?"
+        }
+    }
+}
+

--- a/Sources/GraphRepresentation.swift
+++ b/Sources/GraphRepresentation.swift
@@ -1,0 +1,240 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/// Render the graph to a string.
+public protocol GraphRepresentation {
+    var fileExtension: String { get }
+    func begin()
+    func renderScreenStateNode(name: String, isDismissedOnUse: Bool)
+    func renderScreenActionNode(name: String)
+    func renderEdgeToScreenState(src: String, dest: String, label: String?, isBackable: Bool)
+    func renderEdgeToScreenAction(src: String, dest: String, label: String?)
+    func end()
+    func stringValue() -> String
+}
+
+public extension MMScreenGraph {
+    public func stringRepresentation(_ renderer: GraphRepresentation = DotRepresentation()) -> String {
+        buildGkGraph()
+        renderer.begin()
+        namedScenes.forEach { (name, node) in
+            if let node = node as? MMScreenStateNode {
+                renderer.renderScreenStateNode(name: name, isDismissedOnUse: node.dismissOnUse)
+            } else if let _ = node as? MMScreenActionNode {
+                renderer.renderScreenActionNode(name: name)
+            }
+        }
+
+        namedScenes.forEach { (src, node) in
+            if let node = node as? MMScreenStateNode {
+                node.edges.values.forEach { edge in
+                    guard let dest = namedScenes[edge.destinationName] else { return }
+                    let directed: Bool
+                    if let dest = dest as? MMScreenStateNode {
+                        directed = !dest.hasBack
+                        renderer.renderEdgeToScreenState(src: src,
+                                                         dest: dest.name,
+                                                         label: edge.predicate?.predicateFormat,
+                                                         isBackable: directed)
+                    } else if let _ = dest as? MMScreenActionNode {
+                        renderer.renderEdgeToScreenAction(
+                            src: src,
+                            dest: dest.name,
+                            label: edge.predicate?.predicateFormat)
+                    } else {
+                        return
+                    }
+
+
+                }
+            } else if let node = node as? MMScreenActionNode {
+                if let destName = node.nextNodeName {
+                    renderer.renderEdgeToScreenState(src: src, dest: destName, label: nil, isBackable: true)
+                }
+            }
+        }
+
+        renderer.end()
+        return renderer.stringValue()
+    }
+}
+
+/// The default implementation
+class DotRepresentation: GraphRepresentation {
+    var lines: [String] = []
+
+    var namedIDs: [String: String] = [:]
+    var idGenerator = 0
+
+    let actionColor = "lightblue"
+    let fontActionColor = "white"
+
+    public var fileExtension: String { return "dot" }
+
+    init() {
+    }
+
+    func begin() {
+        lines = []
+        append("digraph G {",
+               "fontsize=15;",
+               "font=Helvetica;",
+               "labelloc=t;",
+               "label=\"\"", "splines=true", "overlap=false", "rankdir = LR;",
+               "ratio = auto;",
+               "node [ shape = box ]"
+        )
+
+        renderLegend()
+    }
+
+    func stringValue() -> String {
+        return lines.joined(separator: "\n")
+    }
+
+    private func append(_ additional: String...) {
+        lines = lines + additional
+    }
+
+    private func id(for name: String) -> String {
+        if let id = namedIDs[name] {
+            return id
+        }
+
+        let id = "_\(idGenerator)"
+        idGenerator += 1
+        namedIDs[name] = id
+        return id
+    }
+
+
+    func renderScreenStateNode(name: String, isDismissedOnUse dismissOnUse: Bool) {
+        let id = self.id(for: name)
+        var styleCode = "label=\"\(name)\"; "
+        if dismissOnUse {
+            styleCode += "fillcolor=lightgray; color=gray; style=filled"
+        } else {
+            styleCode += "color=black"
+        }
+        append("\(id) [ \(styleCode) ];")
+    }
+
+    func renderScreenActionNode(name: String) {
+        let id = self.id(for: name)
+        append("\(id) [ label = \"\(name)\"; shape=egg; style=filled; color=\(actionColor); fillcolor=\(actionColor); fontcolor=\(fontActionColor); fontsize=10];")
+    }
+
+    func renderEdgeToScreenState(src: String, dest: String, label: String?, isBackable: Bool) {
+        var styleCode: String = "[ "
+
+        if let label = label {
+            styleCode += "label=\"\(label)\"; style=dashed"
+        } else {
+            styleCode += "style=solid"
+        }
+
+        if isBackable {
+            styleCode += "; dir=both; arrowtail=obox; arrowhead=normal"
+        } 
+
+        let srcID = id(for: src)
+        let destID = id(for: dest)
+
+        let edgeCode = "->"
+
+        styleCode += " ]"
+
+        append("\(srcID) \(edgeCode) \(destID)\(styleCode);")
+    }
+
+    func renderEdgeToScreenAction(src: String, dest: String, label: String?) {
+        let labelCode: String
+
+        if let label = label {
+            labelCode = " [ label=\"\(label)\"; style=dashed; color=\(actionColor) ]"
+        } else {
+            labelCode = " [ color=\(actionColor) ]"
+        }
+        let srcID = id(for: src)
+        let destID = id(for: dest)
+
+        let edgeCode = "->"
+
+        append("\(srcID) \(edgeCode) \(destID)\(labelCode);")
+    }
+
+    func end() {
+        append("}")
+    }
+
+    func renderLegend() {
+        var i = 1;
+        var labels = [String]()
+        func label(_ string: String) {
+            labels += [("k\(i) [label=\"\(string)\\r\"];")]
+            i += 1
+        }
+
+        append("subgraph cluster_legend {",
+               "fontsize=15;",
+               "label=\"Legend\";")
+
+        namedIDs = [:]
+        renderScreenStateNode(name: "Screen1", isDismissedOnUse: false)
+        renderScreenStateNode(name: "Screen2", isDismissedOnUse: false)
+        renderEdgeToScreenState(src: "Screen1", dest: "Screen2", label: nil, isBackable: false)
+        label("Transition between two screens")
+
+        namedIDs = [:]
+        renderScreenStateNode(name: "Screen1", isDismissedOnUse: false)
+        renderScreenStateNode(name: "Screen2", isDismissedOnUse: false)
+        renderEdgeToScreenState(src: "Screen1", dest: "Screen2", label: "numItems > 0", isBackable: false)
+        label("Transition between two screens\\rconditional on user state")
+
+        namedIDs = [:]
+        renderScreenStateNode(name: "Screen1", isDismissedOnUse: false)
+        renderScreenStateNode(name: "Screen2", isDismissedOnUse: false)
+        renderScreenStateNode(name: "Screen3", isDismissedOnUse: false)
+        renderEdgeToScreenState(src: "Screen1", dest: "Screen3", label: nil, isBackable: true)
+        renderEdgeToScreenState(src: "Screen2", dest: "Screen3", label: nil, isBackable: true)
+        label("Screen3 has a back action\\rto get back to where it came from")
+
+        namedIDs = [:]
+        renderScreenStateNode(name: "Screen1", isDismissedOnUse: false)
+        renderScreenStateNode(name: "Screen2", isDismissedOnUse: true)
+        renderScreenStateNode(name: "Screen3", isDismissedOnUse: false)
+        renderEdgeToScreenState(src: "Screen1", dest: "Screen2", label: nil, isBackable: true)
+        renderEdgeToScreenState(src: "Screen2", dest: "Screen3", label: nil, isBackable: true)
+        label("Screen2 is not added to the back stack.\\rGoing back from Screen3 goes to Screen1")
+
+        namedIDs = [:]
+        renderScreenStateNode(name: "Screen", isDismissedOnUse: false)
+        renderScreenActionNode(name: "Named Action")
+        renderEdgeToScreenAction(src: "Screen", dest: "Named Action", label: nil)
+        label("Named Action can be performed from Screen")
+
+        namedIDs = [:]
+        renderScreenActionNode(name: "Menu-NewTab")
+        renderScreenActionNode(name: "TabTray-NewTab")
+        renderScreenActionNode(name: "NewTab")
+        renderScreenStateNode(name: "NewTabScreen", isDismissedOnUse: false)
+        renderEdgeToScreenAction(src: "Menu-NewTab", dest: "NewTab", label: nil)
+        renderEdgeToScreenAction(src: "TabTray-NewTab", dest: "NewTab", label: nil)
+        renderEdgeToScreenState(src: "NewTab", dest: "NewTabScreen", label: nil, isBackable: false)
+        label("NewTab action can be accessed —\\rand tested — from multiple places.\\rBoth lead to the NewTabScreen.")
+
+
+        append("{",
+            "rank=source",
+            "node [shape=plaintext, style=solid, width=3.5];")
+
+        lines += labels
+
+        append("}")
+
+        append("}")
+    }
+}

--- a/Sources/MMScreenGraph.swift
+++ b/Sources/MMScreenGraph.swift
@@ -181,7 +181,7 @@ public extension MMScreenGraph {
         return MMNavigator(self, xcTest: xcTest, startingScreenState: startingScreenState, userState: userState)
     }
 
-    fileprivate func buildGkGraph() {
+    func buildGkGraph() {
         if isReady {
             return
         }

--- a/UITests/DemoMappaMundi.swift
+++ b/UITests/DemoMappaMundi.swift
@@ -14,9 +14,9 @@ class Actions {
 }
 
 class Screens {
-    static let itemList = "list"
-    static let itemListEditing = "editingList"
-    static let itemDetail = "detail"
+    static let itemList = "ItemList"
+    static let itemListEditing = "EditingItemList"
+    static let itemDetail = "ItemDetail"
 }
 
 class DemoAppUserState: MMUserState {

--- a/UITests/DemoUITests.swift
+++ b/UITests/DemoUITests.swift
@@ -29,7 +29,11 @@ class DemoUITests: XCTestCase {
         // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
         app.launch()
     }
-    
+
+    func testRenderDotfile() {
+        MMTestUtils.render(graph: createGraph(with: app, for: self))
+    }
+
     func testSimpleNavigation() {
         navigator.performAction(Actions.addItem)
         navigator.goto(Screens.itemDetail)


### PR DESCRIPTION
This PR introduces a GraphRepresentation via [graphviz][1] and utilities to write it to disk.

There is also a legend. This is made by using the same primitives used to render the graph, so should change as you style them. No attempt has been made to parameterize the graph representation so users can change the appearance. This should be considered once we get a designer to see how ugly the graph is.

We do not yet call graphviz from the test.

The graph file is dumped in `$HOME/Library/Caches/tools.mappamundi/graph.dot`, or `$HOME/Library/Caches/graph.dot` if you don't create that directory.

You can render the graph using:

```sh
% dot -Tpng $HOME/Library/Caches/tools.mappamundi/graph.dot -ograph.png
```

![graph](https://user-images.githubusercontent.com/99338/35055028-08376372-fba6-11e7-9bfa-bbc31416fe5c.png)

The above is taken from rendering the graph of the test application.

https://bugzilla.mozilla.org/show_bug.cgi?id=1405410

 [1]: https://graphviz.gitlab.io/