### PR TITLE
Add Navigator Actions.

### DIFF
--- a/Sources/GraphRepresentation.swift
+++ b/Sources/GraphRepresentation.swift
@@ -23,7 +23,7 @@ public extension MMScreenGraph {
         namedScenes.forEach { (name, node) in
             if let node = node as? MMScreenStateNode {
                 renderer.renderScreenStateNode(name: name, isDismissedOnUse: node.dismissOnUse)
-            } else if let _ = node as? MMScreenActionNode {
+            } else if let _ = node as? MMActionNode {
                 renderer.renderScreenActionNode(name: name)
             }
         }
@@ -38,7 +38,7 @@ public extension MMScreenGraph {
                                                          dest: dest.name,
                                                          label: edge.predicate?.predicateFormat,
                                                          isBackable: directed)
-                    } else if let _ = dest as? MMScreenActionNode {
+                    } else if let _ = dest as? MMActionNode {
                         renderer.renderEdgeToScreenAction(
                             src: src,
                             dest: dest.name,

--- a/Sources/MMGraphNode.swift
+++ b/Sources/MMGraphNode.swift
@@ -5,23 +5,31 @@
 import Foundation
 import GameplayKit
 
-/// The super class of screen action and screen state nodes.
-/// By design, the user should not be able to construct these nodes.
-public class MMGraphNode<T: MMUserState> {
+public class MMGraphElement {
     let name: String
-    let gkNode: GKGraphNode
-
-    weak var map: MMScreenGraph<T>?
 
     let file: String
     let line: UInt
 
-    init(_ map: MMScreenGraph<T>, name: String, file: String, line: UInt) {
-        self.map = map
+    init(name: String, file: String, line: UInt) {
         self.name = name
         self.file = file
         self.line = line
+    }
+}
+
+/// The super class of screen action and screen state nodes.
+/// By design, the user should not be able to construct these nodes.
+public class MMGraphNode<T: MMUserState>: MMGraphElement {
+    let gkNode: GKGraphNode
+
+    weak var map: MMScreenGraph<T>?
+
+    init(_ map: MMScreenGraph<T>, name: String, file: String, line: UInt) {
+        self.map = map
 
         self.gkNode = GKGraphNode()
+
+        super.init(name: name, file: file, line: line)
     }
 }

--- a/Sources/MMGraphNode.swift
+++ b/Sources/MMGraphNode.swift
@@ -21,6 +21,8 @@ public class MMGraphElement {
 /// The super class of screen action and screen state nodes.
 /// By design, the user should not be able to construct these nodes.
 public class MMGraphNode<T: MMUserState>: MMGraphElement {
+    var nodeType: String { return "Node" }
+
     let gkNode: GKGraphNode
 
     weak var map: MMScreenGraph<T>?

--- a/Sources/MMNavigator.swift
+++ b/Sources/MMNavigator.swift
@@ -43,7 +43,7 @@ open class MMNavigator<T: MMUserState> {
             node.onEnterStateRecorder?(userState)
         } else if let node = currentGraphNode as? MMScreenActionNode<T> {
             node.onEnterStateRecorder?(userState)
-        } else if let node = currentGraphNode as? MMShortcutActionNode<T> {
+        } else if let node = currentGraphNode as? MMNavigatorActionNode<T> {
             node.action(self)
         }
 
@@ -203,13 +203,12 @@ open class MMNavigator<T: MMUserState> {
             return
         }
 
-        if let shortcut = map.namedScenes[actionName] as? MMShortcutActionNode,
+        if let navigatorAction = map.namedScenes[actionName] as? MMNavigatorActionNode,
             !can(performAction: actionName) {
-            shortcut.action(self)
+            navigatorAction.action(self)
         } else {
             goto(actionName, file: file, line: line)
         }
-
     }
 
     func isActionOrFail(_ screenActionName: String, file: String = #file, line: UInt = #line) -> Bool {
@@ -379,7 +378,7 @@ fileprivate extension MMNavigator {
             let onEnterStateRecorder = node.onEnterStateRecorder {
             onEnterStateRecorder(userState)
             return true
-        } else if let node = enteringNode as? MMShortcutActionNode<T> {
+        } else if let node = enteringNode as? MMNavigatorActionNode<T> {
             node.action(self)
             return true
         }

--- a/Sources/MMNavigator.swift
+++ b/Sources/MMNavigator.swift
@@ -196,6 +196,10 @@ open class MMNavigator<T: MMUserState> {
     /// which could be another action or a screen state.
     /// This method will always return the app to a valid screen state.
     public func performAction(_ screenActionName: String, file: String = #file, line: UInt = #line) {
+        if let shortcut = map.shortcutActions[screenActionName] {
+            shortcut.action(self)
+            return
+        }
         if isActionOrFail(screenActionName, file: file, line: line) {
             goto(screenActionName, file: file, line: line)
         }

--- a/Sources/MMNavigator.swift
+++ b/Sources/MMNavigator.swift
@@ -406,3 +406,33 @@ fileprivate extension MMNavigator {
         return graphChanged
     }
 }
+
+/// Helper methods to be used from within tests.
+/// These methods allow tests to wait for an element to reach a condition, or timeout.
+/// If the condition is never reached, the timeout is reported in-line where the navigator was asked to wait.
+public extension MMNavigator {
+    public func waitForExistence(_ element: XCUIElement, timeout: TimeInterval = 7.0, file: String = #file, line: UInt = #line) {
+        waitFor(element, with: "exists == true", timeout: timeout, file: file, line: line)
+    }
+
+    public func waitForNonExistence(_ element: XCUIElement, timeoutValue: TimeInterval = 5.0, file: String = #file, line: UInt = #line) {
+        waitFor(element, with: "exists != true", timeout: timeoutValue, file: file, line: line)
+    }
+
+    public func waitFor(_ element: XCUIElement, toContain value: String, file: String = #file, line: UInt = #line) {
+        waitFor(element, with: "value CONTAINS '\(value)'", file: file, line: line)
+    }
+
+    public func waitFor(_ element: XCUIElement,
+                         with predicateString: String,
+                         description: String? = nil,
+                         timeout: TimeInterval = 5.0,
+                         file: String = #file, line: UInt = #line) {
+
+        let predicate = NSPredicate(format: predicateString)
+        waitOrTimeout(predicate, object: element, timeout: timeout) {
+            let message = description ?? "Expect predicate \(predicateString) for \(element.description)"
+            xcTest.recordFailure(withDescription: message, inFile: file, atLine: line, expected: false)
+        }
+    }
+}

--- a/Sources/MMNavigator.swift
+++ b/Sources/MMNavigator.swift
@@ -38,10 +38,13 @@ open class MMNavigator<T: MMUserState> {
         self.userState = userState
 
         // We should let the initial state update the user state.
+        // This should probably use the enter() methods.
         if let node = currentGraphNode as? MMScreenStateNode<T> {
             node.onEnterStateRecorder?(userState)
         } else if let node = currentGraphNode as? MMScreenActionNode<T> {
             node.onEnterStateRecorder?(userState)
+        } else if let node = currentGraphNode as? MMShortcutActionNode<T> {
+            node.action(self)
         }
 
         // Then, we should update the routable graph with respect
@@ -144,16 +147,16 @@ open class MMNavigator<T: MMUserState> {
             if let node = currentGraphNode as? MMScreenStateNode<T> {
                 leave(node, to: nextScene, file: file, line: line)
                 maybeStateChanged = node.onExitStateRecorder != nil
-            } else if let node = currentGraphNode as? MMScreenActionNode<T> {
+            } else if let node = currentGraphNode as? MMActionNode<T> {
                 leave(node, to: nextScene, file: file, line: line)
             }
 
             if let node = nextScene as? MMScreenStateNode<T> {
                 enter(node, withVisitor: nodeVisitor)
                 maybeStateChanged = maybeStateChanged || node.onEnterStateRecorder != nil
-            } else if let node = nextScene as? MMScreenActionNode<T> {
-                enter(node)
-                maybeStateChanged = maybeStateChanged || node.onEnterStateRecorder != nil
+            } else if let node = nextScene as? MMActionNode<T> {
+                let thisNodeChangedState = enter(node)
+                maybeStateChanged = maybeStateChanged || thisNodeChangedState
             }
             currentGraphNode = nextScene
 
@@ -195,18 +198,22 @@ open class MMNavigator<T: MMUserState> {
     /// Actions can cause userState to change. They only have one edge out,
     /// which could be another action or a screen state.
     /// This method will always return the app to a valid screen state.
-    public func performAction(_ screenActionName: String, file: String = #file, line: UInt = #line) {
-        if let shortcut = map.shortcutActions[screenActionName] {
-            shortcut.action(self)
+    public func performAction(_ actionName: String, file: String = #file, line: UInt = #line) {
+        guard isActionOrFail(actionName, file: file, line: line) else {
             return
         }
-        if isActionOrFail(screenActionName, file: file, line: line) {
-            goto(screenActionName, file: file, line: line)
+
+        if let shortcut = map.namedScenes[actionName] as? MMShortcutActionNode,
+            !can(performAction: actionName) {
+            shortcut.action(self)
+        } else {
+            goto(actionName, file: file, line: line)
         }
+
     }
 
     func isActionOrFail(_ screenActionName: String, file: String = #file, line: UInt = #line) -> Bool {
-        guard let _ = map.namedScenes[screenActionName] as? MMScreenActionNode else {
+        guard let _ = map.namedScenes[screenActionName] as? MMActionNode else {
             xcTest.recordFailure(withDescription: "\(screenActionName) is not an action", inFile: file, atLine: line, expected: false)
             return false
         }
@@ -363,12 +370,21 @@ fileprivate extension MMNavigator {
         nodeVisitor(currentGraphNode.name)
     }
 
-    fileprivate func leave(_ exitingNode: MMScreenActionNode<T>, to nextNode: MMGraphNode<T>, file: String, line: UInt) {
+    fileprivate func leave(_ exitingNode: MMActionNode<T>, to nextNode: MMGraphNode<T>, file: String, line: UInt) {
         // NOOP
     }
 
-    fileprivate func enter(_ enteringNode: MMScreenActionNode<T>) {
-        enteringNode.onEnterStateRecorder?(userState)
+    fileprivate func enter(_ enteringNode: MMActionNode<T>) -> Bool {
+        if let node = enteringNode as? MMScreenActionNode<T>,
+            let onEnterStateRecorder = node.onEnterStateRecorder {
+            onEnterStateRecorder(userState)
+            return true
+        } else if let node = enteringNode as? MMShortcutActionNode<T> {
+            node.action(self)
+            return true
+        }
+
+        return false
     }
 
     func followUpActions(_ lastStep: MMGraphNode<T>) -> [MMGraphNode<T>] {

--- a/Sources/MMScreenActionNode.swift
+++ b/Sources/MMScreenActionNode.swift
@@ -5,27 +5,37 @@
 import Foundation
 import XCTest
 
+public class MMActionNode<T: MMUserState>: MMGraphNode<T> {
+    // marker
+}
+
 // Gestures which affect user state are called ScreenActions.
 // These cannot be constructed or manipulated directly, but can be added to the graph using `screenStateNode.*(forAction:)` methods.
-public class MMScreenActionNode<T: MMUserState>: MMGraphNode<T> {
+public class MMScreenActionNode<T: MMUserState>: MMActionNode<T> {
     public typealias UserStateChange = (T) -> ()
     let onEnterStateRecorder: UserStateChange?
 
     let nextNodeName: String?
+
+    override var nodeType: String { return "Screen action" }
 
     init(_ map: MMScreenGraph<T>, name: String, then nextNodeName: String?, file: String, line: UInt, recorder: UserStateChange?) {
         self.onEnterStateRecorder = recorder
         self.nextNodeName = nextNodeName
         super.init(map, name: name, file: file, line: line)
     }
+
+    
 }
 
-public class MMShortcutActionNode<T: MMUserState>: MMGraphElement {
+public class MMShortcutActionNode<T: MMUserState>: MMActionNode<T> {
     let action: MMShortcutAction<T>
 
-    init(name: String, action: @escaping MMShortcutAction<T>, file: String, line: UInt) {
-        self.action = action
+    override var nodeType: String { return "Shortcut action" }
 
-        super.init(name: name, file: file, line: line)
+    init(_ map: MMScreenGraph<T>, name: String, file: String, line: UInt, shortcut: @escaping MMShortcutAction<T>) {
+        self.action = shortcut
+
+        super.init(map, name: name, file: file, line: line)
     }
 }

--- a/Sources/MMScreenActionNode.swift
+++ b/Sources/MMScreenActionNode.swift
@@ -19,3 +19,13 @@ public class MMScreenActionNode<T: MMUserState>: MMGraphNode<T> {
         super.init(map, name: name, file: file, line: line)
     }
 }
+
+public class MMShortcutActionNode<T: MMUserState>: MMGraphElement {
+    let action: MMShortcutAction<T>
+
+    init(name: String, action: @escaping MMShortcutAction<T>, file: String, line: UInt) {
+        self.action = action
+
+        super.init(name: name, file: file, line: line)
+    }
+}

--- a/Sources/MMScreenActionNode.swift
+++ b/Sources/MMScreenActionNode.swift
@@ -28,13 +28,13 @@ public class MMScreenActionNode<T: MMUserState>: MMActionNode<T> {
     
 }
 
-public class MMShortcutActionNode<T: MMUserState>: MMActionNode<T> {
-    let action: MMShortcutAction<T>
+public class MMNavigatorActionNode<T: MMUserState>: MMActionNode<T> {
+    let action: MMNavigatorAction<T>
 
-    override var nodeType: String { return "Shortcut action" }
+    override var nodeType: String { return "Navigator action" }
 
-    init(_ map: MMScreenGraph<T>, name: String, file: String, line: UInt, shortcut: @escaping MMShortcutAction<T>) {
-        self.action = shortcut
+    init(_ map: MMScreenGraph<T>, name: String, file: String, line: UInt, navigatorAction: @escaping MMNavigatorAction<T>) {
+        self.action = navigatorAction
 
         super.init(map, name: name, file: file, line: line)
     }

--- a/Sources/MMScreenGraph.swift
+++ b/Sources/MMScreenGraph.swift
@@ -98,11 +98,11 @@ extension MMScreenGraph {
         let firstNodeName = actions[0]
         if let existing = namedScenes[firstNodeName] {
             xcTest.recordFailure(withDescription: "Action \(firstNodeName) is defined elsewhere, but should be unique", inFile: file, atLine: line, expected: true)
-            xcTest.recordFailure(withDescription: "Action \(firstNodeName) is defined elsewhere, but should be unique", inFile: existing.file, atLine: existing.line, expected: true)
+            xcTest.recordFailure(withDescription: "\(existing.nodeType) \(firstNodeName) is defined elsewhere, but should be unique", inFile: existing.file, atLine: existing.line, expected: true)
+            return
         }
 
-        if let screenState = screenState,
-            let node = namedScenes[screenState] {
+        if let screenState = screenState, let node = namedScenes[screenState] {
             guard node is MMScreenStateNode || node is MMNavigatorActionNode else {
                 xcTest.recordFailure(withDescription: "Expected \(screenState) to be a screen state or navigator action", inFile: file, atLine: line, expected: false)
                 return

--- a/Sources/MMScreenGraph.swift
+++ b/Sources/MMScreenGraph.swift
@@ -20,7 +20,7 @@ import GameplayKit
 import XCTest
 
 public typealias MMScreenStateBuilder<T: MMUserState> = (MMScreenStateNode<T>) -> Void
-public typealias MMShortcutAction<T: MMUserState> = (MMNavigator<T>) -> Void
+public typealias MMNavigatorAction<T: MMUserState> = (MMNavigator<T>) -> Void
 
 /**
  * ScreenGraph
@@ -84,8 +84,8 @@ public extension MMScreenGraph {
         addOrCheckScreenAction(name, transitionTo: nextNodeName, file: file, line: line, recorder: defaultStateRecorder)
     }
 
-    public func addShortcutAction(_ name: String, file: String = #file, line: UInt = #line, shortcut: @escaping MMShortcutAction<T>) {
-        addOrCheckShortcutAction(name, file: file, line: line, shortcut: shortcut)
+    public func addNavigatorAction(_ name: String, file: String = #file, line: UInt = #line, navigatorAction: @escaping MMNavigatorAction<T>) {
+        addOrCheckNavigatorAction(name, file: file, line: line, navigatorAction: navigatorAction)
     }
 }
 
@@ -103,8 +103,8 @@ extension MMScreenGraph {
 
         if let screenState = screenState,
             let node = namedScenes[screenState] {
-            guard node is MMScreenStateNode || node is MMShortcutActionNode else {
-                xcTest.recordFailure(withDescription: "Expected \(screenState) to be a screen state", inFile: file, atLine: line, expected: false)
+            guard node is MMScreenStateNode || node is MMNavigatorActionNode else {
+                xcTest.recordFailure(withDescription: "Expected \(screenState) to be a screen state or navigator action", inFile: file, atLine: line, expected: false)
                 return
             }
         }
@@ -122,14 +122,14 @@ extension MMScreenGraph {
         }
     }
 
-    fileprivate func addOrCheckShortcutAction(_ name: String, file: String = #file, line: UInt = #line, shortcut: @escaping MMShortcutAction<T>) {
+    fileprivate func addOrCheckNavigatorAction(_ name: String, file: String = #file, line: UInt = #line, navigatorAction: @escaping MMNavigatorAction<T>) {
         if let existing = namedScenes[name] {
             self.xcTest.recordFailure(withDescription: "\(existing.nodeType) \(name) conflicts with an identically named action", inFile: existing.file, atLine: existing.line, expected: false)
             self.xcTest.recordFailure(withDescription: "Action \(name) conflicts with an identically named \(existing.nodeType)", inFile: file, atLine: line, expected: false)
             return
         }
 
-        namedScenes[name] = MMShortcutActionNode(self, name: name, file: file, line: line, shortcut: shortcut)
+        namedScenes[name] = MMNavigatorActionNode(self, name: name, file: file, line: line, navigatorAction: navigatorAction)
     }
 
     fileprivate func addOrCheckScreenAction(_ name: String, transitionTo nextNodeName: String? = nil, file: String = #file, line: UInt = #line, recorder: UserStateChange?) {

--- a/Sources/MMScreenStateNode.swift
+++ b/Sources/MMScreenStateNode.swift
@@ -14,6 +14,8 @@ import XCTest
  * XCUIElement method of moving about.
  */
 public class MMScreenStateNode<T: MMUserState>: MMGraphNode<T> {
+    override var nodeType: String { return "Screen state" }
+
     let builder: MMScreenStateBuilder<T>
     var edges: [String: Edge] = [:]
 

--- a/UITests/DemoMappaMundi.swift
+++ b/UITests/DemoMappaMundi.swift
@@ -11,6 +11,7 @@ class Actions {
     static let editItemMode = "editItems"
     static let deleteItem = "deleteItem"
     static let deleteAllItems = "deleteAllItems"
+    static let initialWithExactlyOne = "initialWithExactlyOne"
 }
 
 class Screens {
@@ -92,6 +93,11 @@ func createGraph(with app: XCUIApplication, for test: XCTestCase) -> MMScreenGra
         }
 
         screenState.backAction = navigationControllerBackAction
+    }
+
+    map.addShortcutAction(Actions.initialWithExactlyOne) { navigator in
+        navigator.performAction(Actions.deleteAllItems)
+        navigator.performAction(Actions.addItem)
     }
 
     return map

--- a/UITests/DemoMappaMundi.swift
+++ b/UITests/DemoMappaMundi.swift
@@ -96,12 +96,12 @@ func createGraph(with app: XCUIApplication, for test: XCTestCase) -> MMScreenGra
         screenState.backAction = navigationControllerBackAction
     }
 
-    map.addShortcutAction(Actions.initialWithExactlyOne) { navigator in
+    map.addNavigatorAction(Actions.initialWithExactlyOne) { navigator in
         navigator.performAction(Actions.deleteAllItems)
         navigator.performAction(Actions.addItem)
     }
 
-    map.addShortcutAction(Actions.postAddItem) { navigator in
+    map.addNavigatorAction(Actions.postAddItem) { navigator in
         print("In \(navigator.screenState)")
     }
 

--- a/UITests/DemoMappaMundi.swift
+++ b/UITests/DemoMappaMundi.swift
@@ -12,6 +12,7 @@ class Actions {
     static let deleteItem = "deleteItem"
     static let deleteAllItems = "deleteAllItems"
     static let initialWithExactlyOne = "initialWithExactlyOne"
+    static let postAddItem = "postAddItem"
 }
 
 class Screens {
@@ -46,7 +47,7 @@ func createGraph(with app: XCUIApplication, for test: XCTestCase) -> MMScreenGra
         // screenState.onEnterWaitFor(element: table)
 
         // 1. an action to add an item to the list.
-        screenState.tap(app.buttons["addButton"], forAction: Actions.addItem) { userState in
+        screenState.tap(app.buttons["addButton"], forAction: Actions.addItem, transitionTo: Actions.postAddItem) { userState in
             userState.numItems += 1
         }
 
@@ -98,6 +99,10 @@ func createGraph(with app: XCUIApplication, for test: XCTestCase) -> MMScreenGra
     map.addShortcutAction(Actions.initialWithExactlyOne) { navigator in
         navigator.performAction(Actions.deleteAllItems)
         navigator.performAction(Actions.addItem)
+    }
+
+    map.addShortcutAction(Actions.postAddItem) { navigator in
+        print("In \(navigator.screenState)")
     }
 
     return map

--- a/UITests/DemoUITests.swift
+++ b/UITests/DemoUITests.swift
@@ -99,4 +99,21 @@ class DemoUITests: XCTestCase {
         XCTAssertEqual(0, userState.numItems)
         XCTAssertFalse(navigator.can(goto: Screens.itemDetail))
     }
+
+    func testShortcutActions() {
+        XCTAssertEqual(0, userState.numItems)
+        XCTAssertFalse(navigator.can(goto: Screens.itemDetail))
+        navigator.performAction(Actions.addItem)
+        navigator.performAction(Actions.addItem)
+        XCTAssertEqual(2, userState.numItems)
+
+        // The shortcut is composed of two actions by the navigator,
+        // so higher level commands can be composed.
+        // It is generally inferior to Swift's own method dispatch
+        // except that it allows for:
+        //  * the graph to be refactored
+        //  * much more regular graph code.
+        navigator.performAction(Actions.initialWithExactlyOne)
+        XCTAssertEqual(1, userState.numItems)
+    }
 }

--- a/UITests/DemoUITests.swift
+++ b/UITests/DemoUITests.swift
@@ -115,5 +115,8 @@ class DemoUITests: XCTestCase {
         //  * much more regular graph code.
         navigator.performAction(Actions.initialWithExactlyOne)
         XCTAssertEqual(1, userState.numItems)
+
+        navigator.performAction(Actions.postAddItem)
+        XCTAssertEqual(2, userState.numItems)
     }
 }

--- a/UITests/DemoUITests.swift
+++ b/UITests/DemoUITests.swift
@@ -100,14 +100,14 @@ class DemoUITests: XCTestCase {
         XCTAssertFalse(navigator.can(goto: Screens.itemDetail))
     }
 
-    func testShortcutActions() {
+    func testNavigatorActions() {
         XCTAssertEqual(0, userState.numItems)
         XCTAssertFalse(navigator.can(goto: Screens.itemDetail))
         navigator.performAction(Actions.addItem)
         navigator.performAction(Actions.addItem)
         XCTAssertEqual(2, userState.numItems)
 
-        // The shortcut is composed of two actions by the navigator,
+        // The navigatorAction is composed of two actions by the navigator,
         // so higher level commands can be composed.
         // It is generally inferior to Swift's own method dispatch
         // except that it allows for:


### PR DESCRIPTION
This PR does two things: 

1. Absorbs some common wait methods in to `navigator`.
2. Adds a new concept of "navigator actions".

The shortcut actions are closures which can be added to the `map`. The closures take a navigator.

They are invoked with `navigator.perfomAction`.

They can be used in two ways: 

 * as a shortcut action to invoke one or more high level tasks.
 * use an `app` object and `navigator.nowAt` to decide which screen state the app is in.
 * as a post action trigger (via `transitionTo:`) to decide which screen state the app is in.

This is especially helpful when an app is stateful or relies on a server: mappamundi can look at the app and decide where on the graph it is meant to be in.

This is added in service of [Lockbox testing](https://github.com/mozilla-lockbox/lockbox-ios/pull/575).