### PR TITLE
Add extension method to fix deprecated XCTestCase method to recordFailure

### DIFF
--- a/MappaMundi.xcodeproj/project.pbxproj
+++ b/MappaMundi.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		39BAD5681FE19B9E00524FB7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 39BAD5671FE19B9E00524FB7 /* Assets.xcassets */; };
 		39BAD56B1FE19B9E00524FB7 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 39BAD5691FE19B9E00524FB7 /* LaunchScreen.storyboard */; };
 		39BAD5761FE19B9E00524FB7 /* DemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39BAD5751FE19B9E00524FB7 /* DemoUITests.swift */; };
+		8ACA60052931696500335139 /* XCTestCase+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACA60042931696500335139 /* XCTestCase+extension.swift */; };
 		CEDB958625A73F5700F1F430 /* AStar in Frameworks */ = {isa = PBXBuildFile; productRef = CEDB958525A73F5700F1F430 /* AStar */; };
 		CEDB958C25A73F9700F1F430 /* AStar in Frameworks */ = {isa = PBXBuildFile; productRef = CEDB958B25A73F9700F1F430 /* AStar */; };
 		CEDB959325A7411C00F1F430 /* AStar in Frameworks */ = {isa = PBXBuildFile; productRef = CEDB959225A7411C00F1F430 /* AStar */; };
@@ -98,6 +99,7 @@
 		39BAD5711FE19B9E00524FB7 /* DemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		39BAD5751FE19B9E00524FB7 /* DemoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoUITests.swift; sourceTree = "<group>"; };
 		39BAD5771FE19B9E00524FB7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8ACA60042931696500335139 /* XCTestCase+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+extension.swift"; sourceTree = "<group>"; };
 		CEDB95A025A7450100F1F430 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -145,6 +147,7 @@
 				3962F22A1FF6A75800999008 /* ScreenGraphEdge.swift */,
 				3962F2281FF6A6C100999008 /* Wait.swift */,
 				39AB5FE71FE4595000008FB3 /* Info.plist */,
+				8ACA60042931696500335139 /* XCTestCase+extension.swift */,
 			);
 			path = MappaMundi;
 			sourceTree = "<group>";
@@ -361,6 +364,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8ACA60052931696500335139 /* XCTestCase+extension.swift in Sources */,
 				1355A49F22C8A53700EB635F /* MMNode.swift in Sources */,
 				1355A4A022C8A53700EB635F /* MMScreenGraph.swift in Sources */,
 				1355A4A122C8A53700EB635F /* MMGraphNode.swift in Sources */,

--- a/MappaMundi/XCTestCase+extension.swift
+++ b/MappaMundi/XCTestCase+extension.swift
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+extension XCTestCase {
+
+    /// An helper method to migrate deprecated recordFailure(:) XCTestCase method to record(:)
+    func recordFailure(description: String,
+                       issueType: XCTIssue.IssueType = .uncaughtException,
+                       filePath: String = #file,
+                       lineNumber: Int = #line) {
+
+        let location = XCTSourceCodeLocation(filePath: filePath, lineNumber: lineNumber)
+        let context = XCTSourceCodeContext(location: location)
+        let issue = XCTIssue(type: issueType,
+                             compactDescription: description,
+                             detailedDescription: nil,
+                             sourceCodeContext: context,
+                             associatedError: nil,
+                             attachments: [])
+        record(issue)
+    }
+}

--- a/Sources/MMNavigator.swift
+++ b/Sources/MMNavigator.swift
@@ -128,14 +128,14 @@ open class MMNavigator<T: MMUserState> {
     public func goto(_ nodeName: String, file: String = #file, line: UInt = #line, visitWith nodeVisitor: @escaping NodeVisitor) {
         let mmSrc = currentGraphNode.mmNode
         guard let mmDest = map.namedScenes[nodeName]?.mmNode else {
-            xcTest.recordFailure(withDescription: "Cannot route to \(nodeName), because it doesn't exist", inFile: file, atLine: Int(line), expected: false)
+            xcTest.recordFailure(description: "Cannot route to \(nodeName), because it doesn't exist")
             return
         }
         
         var mmPath = mmSrc.findPath(to: mmDest)
 
         guard mmPath.count > 0 else {
-            xcTest.recordFailure(withDescription: "Cannot route from \(currentGraphNode.name) to \(nodeName)", inFile: file, atLine: Int(line), expected: false)
+            xcTest.recordFailure(description: "Cannot route from \(currentGraphNode.name) to \(nodeName)")
             return
         }
 
@@ -214,7 +214,7 @@ open class MMNavigator<T: MMUserState> {
 
     func isActionOrFail(_ screenActionName: String, file: String = #file, line: UInt = #line) -> Bool {
         guard let _ = map.namedScenes[screenActionName] as? MMActionNode else {
-            xcTest.recordFailure(withDescription: "\(screenActionName) is not an action", inFile: file, atLine: Int(line), expected: false)
+            xcTest.recordFailure(description: "\(screenActionName) is not an action")
             return false
         }
         return true
@@ -226,10 +226,12 @@ open class MMNavigator<T: MMUserState> {
         }
 
         guard let returnNode = currentScene.returnNode,
-            let _ = currentScene.backAction else {
-                xcTest.recordFailure(withDescription: "No valid back action", inFile: currentScene.file, atLine: Int(currentScene.line), expected: false)
-                xcTest.recordFailure(withDescription: "No valid back action", inFile: file, atLine: Int(line), expected: false)
-                return
+              let _ = currentScene.backAction else {
+            xcTest.recordFailure(description: "No valid back action",
+                                 filePath: currentScene.file,
+                                 lineNumber: Int(currentScene.line))
+            xcTest.recordFailure(description: "No valid back action")
+            return
         }
 
         goto(returnNode.name)
@@ -254,7 +256,7 @@ open class MMNavigator<T: MMUserState> {
      */
     public func nowAt(_ nodeName: String, file: String = #file, line: UInt = #line) {
         guard let newScene = map.namedScenes[nodeName] else {
-            xcTest.recordFailure(withDescription: "Cannot force to unknown \(nodeName). Currently at \(currentGraphNode.name)", inFile: file, atLine: Int(line), expected: false)
+            xcTest.recordFailure(description: "Cannot force to unknown \(nodeName). Currently at \(currentGraphNode.name)")
             return
         }
         currentGraphNode = newScene
@@ -330,11 +332,10 @@ fileprivate extension MMNavigator {
             }
 
             if shouldWait {
-                condition.wait { 
-                    self.xcTest.recordFailure(withDescription: "Unsuccessfully entered \(enteringNode.name)",
-                        inFile: condition.file,
-                        atLine: Int(condition.line),
-                        expected: false)
+                condition.wait {
+                    self.xcTest.recordFailure(description: "Unsuccessfully entered \(enteringNode.name)",
+                                              filePath: condition.file,
+                                              lineNumber: Int(condition.line))
                 }
             }
         }
@@ -452,7 +453,7 @@ public extension MMNavigator {
         let predicate = NSPredicate(format: predicateString)
         waitOrTimeout(predicate, object: element, timeout: timeout) {
             let message = description ?? "Expect predicate \(predicateString) for \(element.description)"
-            xcTest.recordFailure(withDescription: message, inFile: file, atLine: Int(line), expected: false)
+            xcTest.recordFailure(description: message)
         }
     }
 }

--- a/Sources/MMScreenGraph.swift
+++ b/Sources/MMScreenGraph.swift
@@ -95,14 +95,19 @@ extension MMScreenGraph {
 
         let firstNodeName = actions[0]
         if let existing = namedScenes[firstNodeName] {
-            xcTest.recordFailure(withDescription: "Action \(firstNodeName) is defined elsewhere, but should be unique", inFile: file, atLine: Int(line), expected: true)
-            xcTest.recordFailure(withDescription: "\(existing.nodeType) \(firstNodeName) is defined elsewhere, but should be unique", inFile: existing.file, atLine: Int(existing.line), expected: true)
+            xcTest.recordFailure(description: "Action \(firstNodeName) is defined elsewhere, but should be unique",
+                                 issueType: .assertionFailure)
+
+            xcTest.recordFailure(description: "\(existing.nodeType) \(firstNodeName) is defined elsewhere, but should be unique",
+                                 issueType: .assertionFailure,
+                                 filePath: existing.file,
+                                 lineNumber: Int(existing.line))
             return
         }
 
         if let screenState = screenState, let node = namedScenes[screenState] {
             guard node is MMScreenStateNode || node is MMNavigatorActionNode else {
-                xcTest.recordFailure(withDescription: "Expected \(screenState) to be a screen state or navigator action", inFile: file, atLine: Int(line), expected: false)
+                xcTest.recordFailure(description: "Expected \(screenState) to be a screen state or navigator action")
                 return
             }
         }
@@ -122,8 +127,10 @@ extension MMScreenGraph {
 
     fileprivate func addOrCheckNavigatorAction(_ name: String, file: String = #file, line: UInt = #line, navigatorAction: @escaping MMNavigatorAction<T>) {
         if let existing = namedScenes[name] {
-            self.xcTest.recordFailure(withDescription: "\(existing.nodeType) \(name) conflicts with an identically named action", inFile: existing.file, atLine: Int(existing.line), expected: false)
-            self.xcTest.recordFailure(withDescription: "Action \(name) conflicts with an identically named \(existing.nodeType)", inFile: file, atLine: Int(line), expected: false)
+            xcTest.recordFailure(description: "\(existing.nodeType) \(name) conflicts with an identically named action",
+                                 filePath: existing.file,
+                                 lineNumber: Int(existing.line))
+            xcTest.recordFailure(description: "Action \(name) conflicts with an identically named \(existing.nodeType)")
             return
         }
 
@@ -134,17 +141,21 @@ extension MMScreenGraph {
         let actionNode: MMScreenActionNode<T>
         if let existingNode = namedScenes[name] {
             guard let existing = existingNode as? MMScreenActionNode else {
-                self.xcTest.recordFailure(withDescription: "\(existingNode.nodeType) \(name) conflicts with an identically named action", inFile: existingNode.file, atLine: Int(existingNode.line), expected: false)
-                self.xcTest.recordFailure(withDescription: "Action \(name) conflicts with an identically named \(existingNode.nodeType)", inFile: file, atLine: Int(line), expected: false)
+                xcTest.recordFailure(description: "\(existingNode.nodeType) \(name) conflicts with an identically named action",
+                                     filePath: existingNode.file,
+                                     lineNumber: Int(existingNode.line))
+                xcTest.recordFailure(description: "Action \(name) conflicts with an identically named \(existingNode.nodeType)")
                 return
             }
             // The new node has to have the same nextNodeName as the existing node.
             // unless either one of them is nil, so use whichever is the non nil one.
             if let d1 = existing.nextNodeName,
-                let d2 = nextNodeName,
-                d1 != d2 {
-                self.xcTest.recordFailure(withDescription: "\(name) action points to \(d2) elsewhere", inFile: existing.file, atLine: Int(existing.line), expected: false)
-                self.xcTest.recordFailure(withDescription: "\(name) action points to \(d1) elsewhere", inFile: file, atLine: Int(line), expected: false)
+               let d2 = nextNodeName,
+               d1 != d2 {
+                xcTest.recordFailure(description: "\(name) action points to \(d2) elsewhere",
+                                     filePath: existing.file,
+                                     lineNumber: Int(existing.line))
+                xcTest.recordFailure(description: "\(name) action points to \(d2) elsewhere")
                 return
             }
 
@@ -192,10 +203,9 @@ public extension MMScreenGraph {
         buildGraph()
         let userState = userStateType.init()
         guard let name = startingAt ?? userState.initialScreenState,
-            let startingScreenState = namedScenes[name] as? MMScreenStateNode else {
-                xcTest.recordFailure(withDescription: "The app's initial state couldn't be established.",
-                                     inFile: file, atLine: Int(line), expected: false)
-                fatalError("The app's initial state couldn't be established.")
+              let startingScreenState = namedScenes[name] as? MMScreenStateNode else {
+            xcTest.recordFailure(description: "The app's initial state couldn't be established.")
+            fatalError("The app's initial state couldn't be established.")
         }
 
         userState.initialScreenState = startingScreenState.name

--- a/Sources/MMScreenStateNode.swift
+++ b/Sources/MMScreenStateNode.swift
@@ -81,15 +81,19 @@ public extension MMScreenStateNode {
         let edge = Edge(destinationName: nodeName, predicate: predicate, transition: { xcTest, file, line in
             if let el = element {
                 waitOrTimeout(existsPredicate, object: el) {
-                    xcTest.recordFailure(withDescription: "Cannot get from \(self.name) to \(nodeName). See \(declFile):\(declLine)", inFile: file, atLine: Int(line), expected: false)
-                    xcTest.recordFailure(withDescription: "Cannot find \(el)", inFile: declFile, atLine: Int(declLine), expected: false)
+                    xcTest.recordFailure(description: "Cannot get from \(self.name) to \(nodeName). See \(declFile):\(declLine)",
+                                         filePath: file,
+                                         lineNumber: Int(line))
+                    xcTest.recordFailure(description: "Cannot find \(el)",
+                                         filePath: declFile,
+                                         lineNumber: Int(declLine))
                 }
             }
             g()
         })
 
         guard let _ = map?.namedScenes[nodeName] else {
-            map?.xcTest.recordFailure(withDescription: "Node \(nodeName) has not been declared anywhere", inFile: file, atLine: Int(line), expected: false)
+            map?.xcTest.recordFailure(description: "Node \(nodeName) has not been declared anywhere")
             return
         }
         addEdge(nodeName, by: edge)


### PR DESCRIPTION
This will reduce the number of warnings we see in Firefox for iOS while building in the CI.
- Added a extension file `XCTestCase+extension.swift` to add a convenience helper method to fix the deprecation warnings
- Fixed the deprecations with it