### PR TITLE
Bugfix MTE-565 [v111] Increase timeout of app launch

### DIFF
--- a/Sources/Wait.swift
+++ b/Sources/Wait.swift
@@ -32,7 +32,7 @@ class WaitCondition {
 let existsPredicate = NSPredicate(format: "exists == true")
 
 // This is a function for waiting for a condition of an object to come true.
-func waitOrTimeout(_ predicate: NSPredicate = existsPredicate, object: Any, timeout: TimeInterval = 15, timeoutHandler: () -> ()) {
+func waitOrTimeout(_ predicate: NSPredicate = existsPredicate, object: Any, timeout: TimeInterval = 30, timeoutHandler: () -> ()) {
     let expectation = XCTNSPredicateExpectation(predicate: predicate, object: object)
     let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
     if result != .completed {


### PR DESCRIPTION
Some automated tests fail at launch because the app is not started yet. Let's increase the timeout and monitor the test results on Bitrise and MacStadium.